### PR TITLE
Replace one-arm match statements with if-let statements

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -63,49 +63,23 @@ fn main() -> Result<()> {
             .help("Print namespaces currently tracked in MongoDB"))
         .get_matches();
 
-    match matches.value_of("delete") {
-        None => {}
-        _ => {
-            let _command = remove_item_from_db_namespace_table(
-                &mongo_client,
-                matches
-                    .value_of("delete")
-                    .unwrap()
-                    .to_string());
-        }
+    if let Some(deleted) = matches.value_of("delete") {
+        remove_item_from_db_namespace_table(&mongo_client, deleted)?;
     }
     
-    match matches.value_of("known") {
-        None => {}
-        _ => {
-            let namespace = matches.value_of("known").unwrap().to_string();
-            let _command = query_known_namespace(
-                &mongo_client,
-                &http_client,
-                token.to_string(),
-                endpoint.to_string(),
-                namespace
-            );
-        }
+    if let Some(known_namespace) = matches.value_of("known") {
+        query_known_namespace(&mongo_client, &http_client, &token, &endpoint, known_namespace)?;
     }
 
-    match matches.value_of("project") {
-        None => {}
-        _ => {
-            let call = format!("https://{}/oapi/v1/projects/{}", endpoint, &matches.value_of("project").unwrap().to_string());
-            let command = make_api_call(
-                &http_client,
-                call,
-                token);
-            dbg!(Some(command)); 
-        }
+    if let Some(project_name) = matches.value_of("project") {
+        let call = format!("https://{}/oapi/v1/projects/{}", endpoint, project_name);
+        let result = make_api_call(&http_client, &call, &token)?;
+        dbg!(result);
     }
 
-    match matches.occurrences_of("view") {
-        0 => {}
-        _ => {
-            let _command = view_db_namespace_table(&mongo_client);       
-        }
+    if matches.occurrences_of("view") > 0 {
+        view_db_namespace_table(&mongo_client)?;
     }
+
     Ok(())
 }

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -69,12 +69,12 @@ fn main() -> Result<()> {
         .get_matches();
 
     let mut collection = "namespaces";
-    if let Some(namespace) = matches.value_of("whitelist") {
-      collection = "whitelist";
+    if matches.occurrences_of("whitelist") > 0 {
+        collection = "whitelist";
     }
   
     if let Some(deleted) = matches.value_of("delete") {
-        remove_item_from_db_namespace_table(&mongo_client, collection, deleted)?;
+        remove_item_from_db_table(&mongo_client, collection, deleted)?;
     }
     
     if let Some(known_namespace) = matches.value_of("known") {
@@ -88,7 +88,7 @@ fn main() -> Result<()> {
     }
 
     if matches.occurrences_of("view") > 0 {
-        view_db_namespace_table(&mongo_client, collection)?;
+        view_db_table(&mongo_client, collection)?;
     }
 
     Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,11 +16,11 @@ pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 // Make a call to the Openshift API about some namespace info.
 pub fn make_api_call(
     http_client: &reqwest::Client,
-    call: String,
-    token: String,
+    call: &str,
+    token: &str,
 ) -> Result<reqwest::Response> {
     let project_resp = http_client 
-        .get(&call)
+        .get(call)
         .header("Authorization", format!("Bearer {}", token))
         .send()?;
     Ok(project_resp)
@@ -29,9 +29,9 @@ pub fn make_api_call(
 pub fn query_known_namespace(
     mongo_client: &mongodb::Client,
     http_client: &reqwest::Client,
-    token: String,
-    endpoint: String,
-    namespace: String,
+    token: &str,
+    endpoint: &str,
+    namespace: &str,
 ) -> Result<()> {
     // Query a project. Use their namespace to get their admin usernames and the last time they were built.
     println!(
@@ -40,9 +40,9 @@ pub fn query_known_namespace(
     );
     let namespace_info = get_shelflife_info(
         http_client,
-        token.to_string(),
-        endpoint.to_string(),
-        namespace.to_string(),
+        token,
+        endpoint,
+        namespace,
     )?;
     print!("\n > > > API Response > > > ");
     println!(
@@ -84,9 +84,9 @@ pub fn query_known_namespace(
 // Queries the API and returns a Struct with data relevant for shelflife's operation.
 fn get_shelflife_info(
     http_client: &reqwest::Client,
-    token: String,
-    endpoint: String,
-    namespace: String,
+    token: &str,
+    endpoint: &str,
+    namespace: &str,
 ) -> Result<DBItem> {
     let token = format!("Bearer {}", token); // Set up token
 
@@ -189,7 +189,7 @@ fn get_shelflife_info(
 
     // Build the API response
     let api_response = DBItem {
-        name: namespace,
+        name: namespace.to_string(),
         admins: rolebindings_json_vector,
         last_deployment:
             match last_deployments.first() {
@@ -263,13 +263,13 @@ fn add_item_to_db_namespace_table(mongo_client: &mongodb::Client, item: DBItem) 
     Ok(())
 }
 
-pub fn remove_item_from_db_namespace_table(mongo_client: &mongodb::Client, namespace: String) -> Result<()> {
+pub fn remove_item_from_db_namespace_table(mongo_client: &mongodb::Client, namespace: &str) -> Result<()> {
     // Direct connection to a server. Will not look for other servers in the topology.
     let coll = mongo_client
         .db("SHELFLIFE_NAMESPACES")
         .collection("namespaces");
-    coll.find_one_and_delete(doc! {"name": &namespace}, None)
+    coll.find_one_and_delete(doc! {"name": namespace}, None)
         .unwrap();
-    println!("{} has been removed.", &namespace);
+    println!("{} has been removed.", namespace);
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ pub fn make_api_call(
 
 pub fn query_known_namespace(
     mongo_client: &mongodb::Client,
-    collection: String,
+    collection: &str,
     http_client: &reqwest::Client,
     token: &str,
     endpoint: &str,
@@ -52,7 +52,7 @@ pub fn query_known_namespace(
     );
 
     // Query the DB and get back a table of already added namespaces
-    let current_table: Vec<DBItem> = get_db_table(mongo_client, collection.to_string())?;
+    let current_table: Vec<DBItem> = get_db_table(mongo_client, &collection)?;
     
     // Check if the namespace queried for is in the DB, and if not, ask to put it in.
     let queried_namespace = namespace_info.name.to_string();
@@ -80,7 +80,7 @@ pub fn query_known_namespace(
                     println!("\nUnknown table:");
                 }
             }
-            let _table_add = add_item_to_db_table(mongo_client, collection, namespace_info);
+            let _table_add = add_item_to_db_table(mongo_client, &collection, namespace_info);
         } else if input.trim() == "n" {
             println!("Ok.");
         } else {
@@ -243,7 +243,7 @@ fn get_shelflife_info(
     Ok(api_response)
 }
 
-fn get_db_table(mongo_client: &mongodb::Client, collection: String) -> Result<Vec<DBItem>> {
+fn get_db_table(mongo_client: &mongodb::Client, collection: &str) -> Result<Vec<DBItem>> {
     let coll = mongo_client
         .db("SHELFLIFE_NAMESPACES")
         .collection(&collection);
@@ -279,9 +279,9 @@ fn get_db_table(mongo_client: &mongodb::Client, collection: String) -> Result<Ve
     Ok(namespace_table)
 }
 
-pub fn view_db_table(mongo_client: &mongodb::Client, collection: String) -> Result<()> {
+pub fn view_db_table(mongo_client: &mongodb::Client, collection: &str) -> Result<()> {
     // Query the DB and get back a table of already added namespaces
-    let current_table: Vec<DBItem> = get_db_table(mongo_client, collection.to_string())?;
+    let current_table: Vec<DBItem> = get_db_table(mongo_client, collection)?;
     match collection.as_ref() {
         "namespaces" => {
             println!("\nProjects with ShelfLives:");
@@ -306,7 +306,7 @@ pub fn view_db_table(mongo_client: &mongodb::Client, collection: String) -> Resu
     Ok(())
 }
 
-fn add_item_to_db_table(mongo_client: &mongodb::Client, collection: String, item: DBItem) -> Result<()> {
+fn add_item_to_db_table(mongo_client: &mongodb::Client, collection: &str, item: DBItem) -> Result<()> {
     // Direct connection to a server. Will not look for other servers in the topology.
     let coll = mongo_client
         .db("SHELFLIFE_NAMESPACES")
@@ -315,7 +315,7 @@ fn add_item_to_db_table(mongo_client: &mongodb::Client, collection: String, item
     Ok(())
 }
 
-pub fn remove_item_from_db_namespace_table(mongo_client: &mongodb::Client, collection: &str, namespace: &str) -> Result<()> {
+pub fn remove_item_from_db_table(mongo_client: &mongodb::Client, collection: &str, namespace: &str) -> Result<()> {
     // Direct connection to a server. Will not look for other servers in the topology.
     let coll = mongo_client
         .db("SHELFLIFE_NAMESPACES")


### PR DESCRIPTION
So fun fact, if you have a match statement where you only care about one possible variant that your value can be, you can replace it with an [`if-let`] statement. Basically, you only enter the block if the value on the right-hand side is assignable to the left hand side. If it isn't, you just skip the block, just like how an if statement block is skipped if the condition is not true.

[`if-let`]: https://doc.rust-lang.org/rust-by-example/flow_control/if_let.html

The other thing I did here was change the arguments of some of your functions to take `&str` instead of `String`. This comes down to the fact that inside your function, you only care about the contents of the string, you don't necessarily care about who owns the String. If that doesn't quite make sense yet, just trust me that overall this makes things easier (and prevents you from copying data in a lot of cases). Be sure to read up on the differences between String and &str.