### PR TITLE
Add env variables to control mail sending

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,6 +7,8 @@ export DB_ADDR="localhost"
 export DB_PORT="27017"
 
 #email stuff
+export SEND_MAIL="true"
+export MAIL_ROOT="false"
 export EMAIL_SRV=
 export EMAIL_UNAME=
 export EMAIL_PASSWD=

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1644,7 +1644,7 @@ dependencies = [
 
 [[package]]
 name = "shelflife"
-version = "0.1.0"
+version = "1.0.2"
 dependencies = [
  "chrono 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shelflife"
-version = "0.1.0"
+version = "1.0.2"
 authors = ["wilnil"]
 edition = "2018"
 

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -60,7 +60,7 @@ fn main() -> Result<()> {
             .short("k")
             .long("known")
             .value_name("NAMESPACE")
-            .help("Query API and ShelfLife Database for a known namespace. If it is missing from the database, the user is is asked if they want to add it.")
+            .help("Query API and ShelfLife Database for a known namespace. If it is missing from the database, the user is asked if they want to add it.")
             .takes_value(true))
         .arg(Arg::with_name("project")
             .short("p")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,6 +231,27 @@ pub fn check_expiry_dates(
     let email_addr = env::var("EMAIL_ADDRESS")?;
     let email_domain = env::var("EMAIL_DOMAIN")?;
 
+    let send_or_nah = env::var("SENDMAIL")?;
+    let mut usemail = false;
+
+    match send_or_nah.as_str() {
+        "true" => {
+            println!("Configured to send mail.");
+            usemail = true;
+        },
+        "false" => {
+            println!("Configured to NOT send mail. THIS IS REALLY DANGEROUS!");
+            //usemail = false;
+        },
+        _ => {
+            println!("Can't find sendmail. Assuming I should NOT send mail!");
+            println!("THIS IS REALLY DANGEROUS!");
+            //usemail = false;
+        },
+    }
+
+    println!("Got all env variables.");
+
     let mut mailer = SmtpClient::new_simple(&email_srv).unwrap()
         .credentials(Credentials::new(email_uname.to_string(), email_passwd.to_string()))
         .smtp_utf8(true)
@@ -269,22 +290,26 @@ pub fn check_expiry_dates(
 
                     println!("Project has been marked for deletion and removed from ShelfLife DB.");
 
-                    for name in item.admins.iter() {
-                        let strpname = name.replace("\"", "");
-                        println!("Notifying {}", &strpname);
-                        let strpname = name.replace("\"", "");
-                        let email = Email::builder()
-                            .to((format!("{}@{}", strpname, email_domain), strpname)) //TODO: .env variable for email domain. Need to figure out how I can get someone's custom email. I'm guessing that not everyone is going to have the same domain in an org. Low priority.
-                            .from(addr)
-                            .subject("Hi, I nuked your project :)")
-                            .text(format!("Hello! You are receiving this message because your OKD project, {}, has now gone more than 24 weeks without an update ({}). It has been deleted from OKD. You can find a backup of the project in your homedir at <link>. Thank you for using ShelfLife, try not to let your pods get too moldy next time.", &item.name, &item.last_update))
-                            .build();
-                        match email {
-                            Err(_err) => {
-                                println!("Could not send email. Invalid email address?");
-                            },
-                            _ => {
-                                let _mail_result = mailer.send(email.unwrap().into());
+                    // Find the names of the admins and send them M A I L!
+                    if usemail {
+                        println!("Notifying admins...");
+                        for name in item.admins.iter() {
+                            let strpname = name.replace("\"", "");
+                            println!("Notifying {}", &strpname);
+                            let strpname = name.replace("\"", "");
+                            let email = Email::builder()
+                                .to((format!("{}@{}", strpname, email_domain), strpname))
+                                .from(addr)
+                                .subject("Hi, I nuked your project :)")
+                                .text(format!("Hello! You are receiving this message because your OKD project, {}, has now gone more than 24 weeks without an update ({}). It has been deleted from OKD. You can find a backup of the project in your homedir at <link>. Thank you for using ShelfLife, try not to let your pods get too moldy next time.", &item.name, &item.last_update))
+                                .build();
+                            match email {
+                                Err(_err) => {
+                                    println!("Could not send email. Invalid email address?");
+                                },
+                                _ => {
+                                    let _mail_result = mailer.send(email.unwrap().into());
+                                }
                             }
                         }
                     }
@@ -320,43 +345,50 @@ pub fn check_expiry_dates(
                         &deployment, &item.name);
                         let _result = put_call_api(&http_client, &call, String::from(&post))?;
                     }
-
-                    println!("Notifying admins...");
-                    for name in item.admins.iter() {
-                        let strpname = name.replace("\"", "");
-                        println!("Notifying {}", &strpname);
-                        let email = Email::builder()
-                            .to((format!("{}@{}", strpname, email_domain), strpname))
-                            .from(addr)
-                            .subject("Your project's resources have been revoked.")
-                            .text(format!("Hello! You are receiving this message because your OKD project, {}, has now gone more than 16 weeks without an update ({}). All applications on the project have now been reduced to 0 pods. If you would like to revive it, do so, and its ShelfLife will reset. Otherwise, it will be deleted in another 8 weeks.", &item.name, &item.last_update))
-                            .build();
-                        match email {
-                            Err(_err) => {
-                                println!("Could not send email. Invalid email address?");
-                            },
-                            _ => {
-                                let _mail_result = mailer.send(email.unwrap().into());
+                    
+                    if usemail {    
+                        // Find the names of the admins and send them M A I L!
+                        println!("Notifying admins...");
+                        for name in item.admins.iter() {
+                            let strpname = name.replace("\"", "");
+                            println!("Notifying {}", &strpname);
+                            let email = Email::builder()
+                                .to((format!("{}@{}", strpname, email_domain), strpname))
+                                .from(addr)
+                                .subject("Your project's resources have been revoked.")
+                                .text(format!("Hello! You are receiving this message because your OKD project, {}, has now gone more than 16 weeks without an update ({}). All applications on the project have now been reduced to 0 pods. If you would like to revive it, do so, and its ShelfLife will reset. Otherwise, it will be deleted in another 8 weeks.", &item.name, &item.last_update))
+                                .build();
+                            match email {
+                                Err(_err) => {
+                                    println!("Could not send email. Invalid email address?");
+                                },
+                                _ => {
+                                    let _mail_result = mailer.send(email.unwrap().into());
+                                }
                             }
                         }
                     }
                 }else  if age > chrono::Duration::weeks(12) {
                     println!("The last update to {} was more than 12 weeks ago.", &item.name);
-                    for name in item.admins.iter() {
-                        let strpname = name.replace("\"", "");
-                        println!("Notifying {}", &strpname);
-                        let email = Email::builder()
-                            .to((format!("{}@{}", strpname, email_domain), strpname))
-                            .from(addr)
-                            .subject(format!("Old OKD project: {}", &item.name))
-                            .text(format!("Hello! You are receiving this message because your OKD project, {}, has gone more than 12 weeks without an update ({}). Please consider updating with a build, deployment, or asking an RTP to put the project on ShelfLife's whitelist. Thanks!.", &item.name, &item.last_update))
-                            .build();
-                        match email {
-                            Err(_err) => {
-                                println!("Could not send email. Invalid email address?");
-                            },
-                            _ => {
-                                let _mail_result = mailer.send(email.unwrap().into());
+                    if usemail {    
+                        // Find the names of the admins and send them M A I L!
+                        println!("Notifying admins...");
+                        for name in item.admins.iter() {
+                            let strpname = name.replace("\"", "");
+                            println!("Notifying {}", &strpname);
+                            let email = Email::builder()
+                                .to((format!("{}@{}", strpname, email_domain), strpname))
+                                .from(addr)
+                                .subject(format!("Old OKD project: {}", &item.name))
+                                .text(format!("Hello! You are receiving this message because your OKD project, {}, has gone more than 12 weeks without an update ({}). Please consider updating with a build, deployment, or asking an RTP to put the project on ShelfLife's whitelist. Thanks!.", &item.name, &item.last_update))
+                                .build();
+                            match email {
+                                Err(_err) => {
+                                    println!("Could not send email. Invalid email address?");
+                                },
+                                _ => {
+                                    let _mail_result = mailer.send(email.unwrap().into());
+                                }
                             }
                         }
                     }
@@ -375,11 +407,11 @@ pub fn export_project(project: &str) -> Result<()> {
     let token = env::var("OKD_TOKEN")?;
     let endpoint = env::var("ENDPOINT")?;
     let fail = "failed to execute process";
-    let path = "~/shelflife_backup";
+    let path = "/home/wilnil/shelflife_backup";
 
     // Export project
-    Command::new("sh").arg("-c").arg("mkdir ~/shelflife_backup")
-    .current_dir("~/").status().expect(fail);
+    Command::new("sh").arg("-c").arg(format!("mkdir {}", path))
+    .current_dir("/").status().expect(fail);
     Command::new("sh").arg("-c").arg(format!("oc login https://{} --token={}", endpoint, token))
     .current_dir(path).status().expect(fail);
     Command::new("sh").arg("-c").arg(format!("mkdir {}/{}", path, project))
@@ -392,12 +424,12 @@ pub fn export_project(project: &str) -> Result<()> {
     let items = vec!["rolebindings", "serviceaccounts", "secrets", "imagestreamtags", "podpreset", "cms", "egressnetworkpolicies", "rolebindingrestrictions", "limitranges", "resourcequotas", "pvcs", "templates", "cronjobs", "statefulsets", "hpas", "deployments", "replicasets", "poddisruptionbudget", "endpoints"];
     for object in items {
         Command::new("sh").arg("-c").arg(format!("oc get -o yaml --export {} > {}/{}.yaml", object, project, object))
-    .current_dir("/tmp/backup_test").output().expect(fail);
+    .current_dir(path).output().expect(fail);
         println!("Done with GET for export {}", object);
     }
 
     //Compress it
-    Command::new("sh").arg("-c").arg(format!("zip -r {}.zip {}", project, project)).current_dir("/tmp/backup_test").output().expect(fail); 
+    Command::new("sh").arg("-c").arg(format!("zip -r {}.zip {}", project, project)).current_dir(path).output().expect(fail); 
     Ok(())
 }
 


### PR DESCRIPTION
This allows developers and admins to avoid bothering people when working on or testing ShelfLife. @mxmeinhold