### PR TITLE
Add function to check for env variable presence

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -8,6 +8,7 @@ use dotenv::dotenv;
 use mongodb::ThreadedClient;
 
 use shelflife::{
+                check_env,
                 query_known_namespace,
                 check_expiry_dates,
                 get_call_api,
@@ -18,7 +19,10 @@ use shelflife::{
             };
 
 fn main() -> Result<()> {
-    dotenv().ok();
+    //TODO: Investigate if this is the best way to go about
+    // figuring out if env variables exist.
+    dotenv().ok(); //dotenv's error messages suck.
+    check_env(); // So let's make our own!
     let endpoint = env::var("ENDPOINT")?;
     
     let http_client = reqwest::Client::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
 
 // Let's make sure those environment variables are set, yea?
 pub fn check_env() -> Result<()> { // TODO: Actually use results.
-    let variables = vec!("OKD TOKEN", "DB_ADDR", "DB_PORT", "SEND_MAIL", "MAIL_ROOT", "EMAIL_SRV","EMAIL_UNAME", "EMAIL_PASSWD", "EMAIL_ADDRESS", "EMAIL_DOMAIN"); 
+    let variables = vec!("OKD_TOKEN", "DB_ADDR", "DB_PORT", "SEND_MAIL", "MAIL_ROOT", "EMAIL_SRV","EMAIL_UNAME", "EMAIL_PASSWD", "EMAIL_ADDRESS", "EMAIL_DOMAIN"); 
 
     for i in variables {
         match env::var(i) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,8 +19,29 @@ use lettre::smtp::ConnectionReuseParameters;
 use lettre_email::Email;
 use std::process::Command;
 use std::env;
+// TODO: use std::env::VarError;
 
 pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;
+
+// Let's make sure those environment variables are set, yea?
+pub fn check_env() -> Result<()> { // TODO: Actually use results.
+    let variables = vec!("OKD TOKEN", "DB_ADDR", "DB_PORT", "SEND_MAIL", "MAIL_ROOT", "EMAIL_SRV","EMAIL_UNAME", "EMAIL_PASSWD", "EMAIL_ADDRESS", "EMAIL_DOMAIN"); 
+
+    for i in variables {
+        match env::var(i) {
+            Ok(okd_token) => {
+                if okd_token == "" {
+                    println!("Can't find {}! This'll produce a TON of errors!", i);
+                } else {
+                    println!("Found {}.", i);
+                }
+            },
+            Err(e) => println!("Can't find {}! {}", i, e),
+        };
+    }
+
+    Ok(()) // All env variables found
+}
 
 /*                                  PROJECT FUNCTIONS  */
 /* --------------------------------------------------  */


### PR DESCRIPTION
An issue that has been an issue since last July is that missing environment variables sometimes silently fail, or cause cryptic errors, or cause panics, or something else dumb and stupid. This PR adds a function to—at the very least—check for the presence of environment variables. TODO is, well, do something about it. Also add better error handling, but that's coming.

Closes #48 
Closes #40 
Opens #54 