### PR TITLE
Fix error on nightly rustc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -814,7 +814,7 @@ fn add_item_to_db(mongo_client: &mongodb::Client, collection: &str, item: DBItem
         .db("SHELFLIFE")
         .collection(&collection);
     coll.insert_one(doc!{"name": item.name,
-                         "admins": bson::to_bson(&item.admins)?,
+                         "admins": mongodb::to_bson(&item.admins)?,
                          "discovery_date": item.discovery_date, 
                          "last_update": item.last_update, 
                          "cause": item.cause}, None)


### PR DESCRIPTION
Looks like this crate relies on a deprecated functionality in `rustc` - `use mongodb::bson` imports a private `extern crate` item from a different crate.
This was found during ecosystem testing in https://github.com/rust-lang/rust/pull/80763.
This PR fixes the issue.